### PR TITLE
feat: enhance getGitHubPRDiff to handle large files and escape dollar sign

### DIFF
--- a/src/tools/addPRSummaryComment.ts
+++ b/src/tools/addPRSummaryComment.ts
@@ -40,10 +40,11 @@ function addSummaryCommentToPR(
     const prNumber = getPRNumberFromUrl(url);
     const { owner, repo } = getRepoInfoFromUrl(url);
 
-    // Escape quotes and backticks in comment message
+    // Escape quotes, backticks, and $ in comment message
     const escapedComment = commentMessage
       .replace(/"/g, '\\"')
-      .replace(/`/g, "\\`");
+      .replace(/`/g, "\\`")
+      .replace(/\$/g, "\\$");
 
     // Use gh api to add comment
     execSync(

--- a/src/tools/codeReviewWithGithubUrl.ts
+++ b/src/tools/codeReviewWithGithubUrl.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import dotenv from "dotenv";
-import { execSync } from "child_process";
 
 import { getNotionContent } from "../utils/getNotionContent.js";
 import { getInstructions } from "../utils/getInstructions.js";

--- a/src/utils/getGitHandler.ts
+++ b/src/utils/getGitHandler.ts
@@ -1,5 +1,6 @@
 import { execSync } from "child_process";
 import { ValidationResult } from "../types/validationResult.js";
+import { getPRNumberFromUrl, getRepoInfoFromUrl } from "./parseGithubUrl.js";
 
 export const getCurrentBranch = (folderPath: string) => {
   return execSync(`git -C "${folderPath}" rev-parse --abbrev-ref HEAD`, {
@@ -207,19 +208,81 @@ export function formatDiffWithLineNumbers(diffContent: string): string {
   return formattedLines.join("\n");
 }
 
+const LARGE_FILE_THRESHOLD = 1000;
+const getFilesFromGithub = (prUrl: string) => {
+  const filesJson = execSync(
+    `gh pr view ${prUrl} --json files --jq '.files | map({ path: .path, changes: (.additions + .deletions) })'`
+  ).toString();
+  return JSON.parse(filesJson) as Array<{
+    path: string;
+    changes: number;
+  }>;
+};
+const getDiffFromFiles = (
+  prUrl: string,
+  files: Array<{ path: string; changes: number }>
+) => {
+  const { owner, repo } = getRepoInfoFromUrl(prUrl);
+  const prNumber = getPRNumberFromUrl(prUrl);
+  let combinedDiff = "";
+
+  const largeFiles = files.filter(
+    (file) => file.changes > LARGE_FILE_THRESHOLD
+  );
+  const normalFiles = files.filter(
+    (file) => file.changes <= LARGE_FILE_THRESHOLD
+  );
+
+  if (largeFiles.length > 0) {
+    combinedDiff += "Large files (changes > 1000) that were skipped:\n";
+    largeFiles.forEach((file) => {
+      combinedDiff += `diff --git a/${file.path} b/${file.path}\n`;
+      combinedDiff += `@@ File too large to display (${file.changes} changes) @@\n\n`;
+    });
+  }
+
+  for (const file of normalFiles) {
+    const patch = execSync(
+      `gh api repos/${owner}/${repo}/pulls/${prNumber}/files --jq '.[] | select(.filename == "${file.path}") | .patch'`
+    ).toString();
+
+    if (patch && patch.trim() !== "") {
+      // A simple file header.
+      combinedDiff += `diff --git a/${file.path} b/${file.path}\n`;
+      // The patch from `gh api ... .patch` should contain the --- and +++ lines.
+      combinedDiff += patch;
+      // Ensure a newline separates patches from different files if not already present.
+      if (!patch.endsWith("\n")) {
+        combinedDiff += "\n";
+      }
+    }
+  }
+
+  return combinedDiff;
+};
+
 /**
  * Fetches diff content from a GitHub PR URL using gh CLI
  */
 export function getGitHubPRDiff(prUrl: string): ValidationResult<string> {
   try {
-    // Execute gh pr diff command
-    const diff = execSync(`gh pr diff ${prUrl}`).toString();
+    // Get file changes
+    const files = getFilesFromGithub(prUrl);
+
+    // Check if any file has more than 1000 changes
+    const hasLargeFile = files.some(
+      (file) => file.changes > LARGE_FILE_THRESHOLD
+    );
+
+    const diff = hasLargeFile
+      ? getDiffFromFiles(prUrl, files)
+      : execSync(`gh pr diff ${prUrl}`).toString();
 
     if (!diff || diff.trim() === "") {
       return {
         isValid: false,
         errorMessage:
-          "No differences found in the pull request or invalid PR URL.",
+          "No differences found in the pull request or invalid PR URL",
       };
     }
 


### PR DESCRIPTION
# 🔄 Changes
This PR introduces improvements to handle large files and enhance security in GitHub PR operations:

## 🛠 Technical Changes
1. Added large file handling mechanism
   - Introduced `LARGE_FILE_THRESHOLD` (1000 lines) to identify large files
   - Implemented separate handling for files exceeding the threshold
   - Added summary information for large files in diff output

2. Enhanced security in PR comment handling
   - Added escaping for `$` characters in comment messages
   - Prevents potential shell command injection issues

3. Code cleanup
   - Removed unused `execSync` import from `codeReviewWithGithubUrl.ts`