### PR TITLE
Fix: improve GitHub API call format in PR line comments

### DIFF
--- a/src/utils/githubProvider/cliProvider.ts
+++ b/src/utils/githubProvider/cliProvider.ts
@@ -116,17 +116,10 @@ export class CliGitHubDiffProvider extends BaseGitHubDiffProvider {
         .trim();
 
       const formattedComment = formatComment(commentMessage);
-      const jsonParams = `{
-        "body": "${formattedComment}",
-        "commit_id": "${commitId}",
-        "path": "${filePath}",
-        "line": ${line},
-        "side": "RIGHT"
-      }`;
 
       // Use gh api to add line comment
       execSync(
-        `gh api -X POST -H "Content-Type: application/json" --input - /repos/${owner}/${repo}/pulls/${prNumber}/comments <<< '${jsonParams}'`,
+        `gh api -X POST -F body="${formattedComment}" -F commit_id="${commitId}" -F path="${filePath}" -F line=${line} /repos/${owner}/${repo}/pulls/${prNumber}/comments`,
       );
 
       return 'Line comment added successfully';


### PR DESCRIPTION
## Changes
- Refactored the PR line comment API call in `cliProvider.ts` to use `-F` parameter format instead of JSON string
- This change improves code stability by letting the `gh` CLI handle parameter escaping