### PR TITLE
feat: add getLocalGitDiff tool for raw diff output

### DIFF
--- a/src/tools/codeReview.ts
+++ b/src/tools/codeReview.ts
@@ -34,13 +34,6 @@ type CodeReviewArgs = z.infer<typeof CodeReviewToolSchema>;
 export async function runCodeReviewTool(args: CodeReviewArgs): Promise<ToolResponse> {
   const { folderPath, baseBranch } = args;
 
-  // Validate required parameters
-  if (!baseBranch) {
-    return createErrorResponse(
-      "Please provide a base branch name using the 'baseBranch' parameter. This is required to perform a git diff operation.",
-    );
-  }
-
   // Validate git branch state
   const currentBranchResult = validateCurrentBranch(folderPath);
   if (!currentBranchResult.isValid) {
@@ -51,6 +44,13 @@ export async function runCodeReviewTool(args: CodeReviewArgs): Promise<ToolRespo
   const baseBranchResult = validateBaseBranch(folderPath, baseBranch);
   if (!baseBranchResult.isValid) {
     return createErrorResponse(baseBranchResult.errorMessage);
+  }
+
+  // Check if current branch is the same as base branch
+  if (currentBranchResult.data === baseBranchResult.data) {
+    return createErrorResponse(
+      `Current branch "${currentBranchResult.data}" is the same as base branch "${baseBranchResult.data}". No differences to review.`,
+    );
   }
 
   // Perform git diff

--- a/src/tools/codeReview.ts
+++ b/src/tools/codeReview.ts
@@ -44,19 +44,19 @@ export async function runCodeReviewTool(args: CodeReviewArgs): Promise<ToolRespo
   // Validate git branch state
   const currentBranchResult = validateCurrentBranch(folderPath);
   if (!currentBranchResult.isValid) {
-    return createErrorResponse(currentBranchResult.errorMessage!);
+    return createErrorResponse(currentBranchResult.errorMessage);
   }
 
   // Resolve base branch
   const baseBranchResult = validateBaseBranch(folderPath, baseBranch);
   if (!baseBranchResult.isValid) {
-    return createErrorResponse(baseBranchResult.errorMessage!);
+    return createErrorResponse(baseBranchResult.errorMessage);
   }
 
   // Perform git diff
   const diffResult = performGitDiff(folderPath, baseBranchResult.data!, currentBranchResult.data!);
   if (!diffResult.isValid) {
-    return createErrorResponse(diffResult.errorMessage!);
+    return createErrorResponse(diffResult.errorMessage);
   }
 
   const instructions = await getInstructions({

--- a/src/tools/getLocalGitDiff.ts
+++ b/src/tools/getLocalGitDiff.ts
@@ -29,13 +29,6 @@ type LocalGitDiffArgs = z.infer<typeof LocalGitDiffToolSchema>;
 export async function runLocalGitDiffTool(args: LocalGitDiffArgs): Promise<ToolResponse> {
   const { folderPath, baseBranch } = args;
 
-  // Validate required parameters
-  if (!baseBranch) {
-    return createErrorResponse(
-      "Please provide a base branch name using the 'baseBranch' parameter. This is required to perform a git diff operation.",
-    );
-  }
-
   // Validate git branch state
   const currentBranchResult = validateCurrentBranch(folderPath);
   if (!currentBranchResult.isValid) {

--- a/src/tools/getLocalGitDiff.ts
+++ b/src/tools/getLocalGitDiff.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import {
+  validateCurrentBranch,
+  validateBaseBranch,
+  performGitDiff,
+} from '../utils/getGitHandler.js';
+import { createResponse, createErrorResponse } from '../utils/createResponse.js';
+import type { ToolResponse } from '../utils/createResponse.js';
+
+/**
+ * Local Git Diff tool
+ * - Returns the raw git diff between two branches without review instructions
+ */
+
+export const localGitDiffToolName = 'getLocalGitDiff';
+export const localGitDiffToolDescription =
+  'Get git diff between two branches locally. Returns raw diff output without review instructions.';
+
+export const LocalGitDiffToolSchema = z.object({
+  folderPath: z.string().min(1, 'A folder path is required.'),
+  baseBranch: z.string().min(1, 'A base branch name is required.'),
+});
+
+type LocalGitDiffArgs = z.infer<typeof LocalGitDiffToolSchema>;
+
+/**
+ * Main function to run the local git diff tool
+ */
+export async function runLocalGitDiffTool(args: LocalGitDiffArgs): Promise<ToolResponse> {
+  const { folderPath, baseBranch } = args;
+
+  // Validate required parameters
+  if (!baseBranch) {
+    return createErrorResponse(
+      "Please provide a base branch name using the 'baseBranch' parameter. This is required to perform a git diff operation.",
+    );
+  }
+
+  // Validate git branch state
+  const currentBranchResult = validateCurrentBranch(folderPath);
+  if (!currentBranchResult.isValid) {
+    return createErrorResponse(currentBranchResult.errorMessage!);
+  }
+
+  // Resolve base branch
+  const baseBranchResult = validateBaseBranch(folderPath, baseBranch);
+  if (!baseBranchResult.isValid) {
+    return createErrorResponse(baseBranchResult.errorMessage!);
+  }
+
+  // Perform git diff
+  const diffResult = performGitDiff(folderPath, baseBranchResult.data!, currentBranchResult.data!);
+  if (!diffResult.isValid) {
+    return createErrorResponse(diffResult.errorMessage!);
+  }
+
+  // Return pure diff without instructions
+  const message = `Git Diff Output:\n${diffResult.data}`;
+
+  return createResponse(message);
+}

--- a/src/tools/getLocalGitDiff.ts
+++ b/src/tools/getLocalGitDiff.ts
@@ -32,19 +32,26 @@ export async function runLocalGitDiffTool(args: LocalGitDiffArgs): Promise<ToolR
   // Validate git branch state
   const currentBranchResult = validateCurrentBranch(folderPath);
   if (!currentBranchResult.isValid) {
-    return createErrorResponse(currentBranchResult.errorMessage!);
+    return createErrorResponse(currentBranchResult.errorMessage);
   }
 
   // Resolve base branch
   const baseBranchResult = validateBaseBranch(folderPath, baseBranch);
   if (!baseBranchResult.isValid) {
-    return createErrorResponse(baseBranchResult.errorMessage!);
+    return createErrorResponse(baseBranchResult.errorMessage);
+  }
+
+  // Check if current branch is the same as base branch
+  if (currentBranchResult.data === baseBranchResult.data) {
+    return createErrorResponse(
+      `Current branch "${currentBranchResult.data}" is the same as base branch "${baseBranchResult.data}". No differences to show.`,
+    );
   }
 
   // Perform git diff
   const diffResult = performGitDiff(folderPath, baseBranchResult.data!, currentBranchResult.data!);
   if (!diffResult.isValid) {
-    return createErrorResponse(diffResult.errorMessage!);
+    return createErrorResponse(diffResult.errorMessage);
   }
 
   // Return pure diff without instructions

--- a/src/tools/toolRegistry.ts
+++ b/src/tools/toolRegistry.ts
@@ -43,6 +43,13 @@ import {
   runCreatePRTool,
 } from './createPR.js';
 
+import {
+  localGitDiffToolName,
+  localGitDiffToolDescription,
+  LocalGitDiffToolSchema,
+  runLocalGitDiffTool,
+} from './getLocalGitDiff.js';
+
 /**
  * Tool registry interface for better type safety and maintainability
  */
@@ -79,6 +86,30 @@ const TOOL_REGISTRY: Record<string, ToolDefinition> = {
     handler: async (args) => {
       const validated = CodeReviewToolSchema.parse(args);
       return await runCodeReviewTool(validated);
+    },
+  },
+
+  [localGitDiffToolName]: {
+    name: localGitDiffToolName,
+    description: localGitDiffToolDescription,
+    schema: {
+      type: 'object',
+      properties: {
+        folderPath: {
+          type: 'string',
+          description: 'Path to the full root directory of the repository to run git diff',
+        },
+        baseBranch: {
+          type: 'string',
+          description:
+            'Name of the base branch to compare against the current branch (required). Specifies the reference point for diff comparison.',
+        },
+      },
+      required: ['folderPath', 'baseBranch'],
+    },
+    handler: async (args) => {
+      const validated = LocalGitDiffToolSchema.parse(args);
+      return await runLocalGitDiffTool(validated);
     },
   },
 


### PR DESCRIPTION
# Purpose
Add a new tool `getLocalGitDiff` that returns raw git diff output between branches without review instructions, providing more flexibility for users who need pure diff data.

## Changes
- Added new `getLocalGitDiff.ts` tool that returns raw git diff without review instructions
- Updated `codeReview.ts` to improve error handling and add branch comparison validation
- Registered the new tool in `toolRegistry.ts` with proper schema and handler
- Enhanced error messages to be more descriptive and removed unnecessary non-null assertions

## How to Review
- Start with `src/tools/getLocalGitDiff.ts` to understand the new tool functionality
- Review changes in `src/tools/codeReview.ts` for improved error handling
- Check `src/tools/toolRegistry.ts` for proper tool registration

## Notes
This tool complements the existing code review tool by providing raw diff output for users who need unprocessed git diff data for their own analysis or processing.