### PR TITLE
feat: Add milestone support for CLI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ The tool will:
 - Use the current branch as the source branch
 - Verify that the current branch has been pushed to remote
 - Create the PR using GitHub CLI or REST API
+- Support creating draft PRs and assigning milestones
 
 **Manual override** (if auto-detection fails):
 

--- a/src/tools/toolRegistry.ts
+++ b/src/tools/toolRegistry.ts
@@ -251,6 +251,10 @@ const TOOL_REGISTRY: Record<string, ToolDefinition> = {
           type: 'boolean',
           description: 'Whether to create as draft PR (optional, defaults to false)',
         },
+        milestone: {
+          type: 'string',
+          description: 'Milestone to assign to the PR (optional)',
+        },
       },
       required: ['folderPath', 'title', 'body', 'baseBranch'],
     },

--- a/src/utils/githubProvider/cliProvider.ts
+++ b/src/utils/githubProvider/cliProvider.ts
@@ -131,6 +131,7 @@ export class CliGitHubDiffProvider extends BaseGitHubDiffProvider {
     baseBranch,
     currentBranch,
     draft,
+    milestone,
   }: {
     owner: string;
     repo: string;
@@ -139,6 +140,7 @@ export class CliGitHubDiffProvider extends BaseGitHubDiffProvider {
     baseBranch: string;
     currentBranch: string;
     draft: boolean;
+    milestone?: string;
   }): Promise<string> {
     try {
       // Build gh CLI command with optional --draft flag
@@ -151,6 +153,10 @@ export class CliGitHubDiffProvider extends BaseGitHubDiffProvider {
 
       if (draft) {
         command += ' --draft';
+      }
+
+      if (milestone) {
+        command += ` --milestone "${escapeShellArg(milestone)}"`;
       }
 
       const result = execSync(command).toString();


### PR DESCRIPTION
# Purpose
Add milestone support to the CLI GitHub provider for creating PRs with assigned milestones.

## Changes
- Added `milestone` parameter to the `createPR` tool definition in `toolRegistry.ts`
- Updated `CliGitHubDiffProvider.createPR` method to accept and handle milestone parameter
- Added milestone assignment logic using GitHub CLI `--milestone` flag
- Updated README.md to document milestone support feature

## How to Review
- Review the parameter addition in `src/tools/toolRegistry.ts`
- Check the milestone handling logic in `src/utils/githubProvider/cliProvider.ts`
- Verify that the milestone parameter is properly escaped for shell execution
- Test the feature by creating a PR with a milestone assigned

## Notes
- The milestone parameter is optional and defaults to undefined
- Uses shell argument escaping to prevent injection attacks
- Compatible with existing GitHub CLI milestone functionality