### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push version bump commit / tag and create the GitHub Release
+      id-token: write # mint the OIDC token for npm trusted publishing
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,6 +30,10 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      # OIDC trusted publishing requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Extract version from branch name
         id: extract_version
@@ -74,23 +81,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
-      - name: Verify npm authentication
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
-
       - name: Install dependencies
         run: npm install
 
       - name: Build package
         run: npm run build
 
+      # Auth is handled by npm OIDC trusted publishing (no NPM_TOKEN needed).
+      # Requires a Trusted Publisher configured on npmjs.com for this repo + release.yml.
       - name: Publish to NPM
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Why

The `NPM_TOKEN` secret expired — the release workflow failed at `npm whoami` with **401 Unauthorized** (see [run 28766029388](https://github.com/Orcus2021/code-review-mcp-server/actions/runs/28766029388)), so the 1.5.2 publish never happened.

Rather than mint another long-lived token that will expire again, switch CI to **OIDC trusted publishing**: GitHub Actions mints a short-lived, single-use identity token at publish time and npm verifies it came from this repo's `release.yml`. No token stored, nothing to expire or leak, and npm provenance is attached automatically.

## Changes to `release.yml`

- Add job permissions `id-token: write` (mint the OIDC token) + `contents: write`
- Upgrade npm to `>= 11.5.1` on the runner (Node 22 ships npm 10.x, which predates OIDC trusted publishing)
- Remove the token-based `npm whoami` verification step
- Drop `NODE_AUTH_TOKEN` / `NPM_CONFIG_USERCONFIG` from the publish step

## Notes

- Takes effect for the **next** release (1.5.3+). The stuck 1.5.2 (tag + version bump already pushed to `main`, but not published to npm) needs a one-off manual publish by the maintainer.
- Once a real OIDC publish succeeds, "Publishing access" can be tightened to *Require 2FA and disallow tokens* for maximum security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)