### PR TITLE
ci: bring OIDC trusted publishing to main (needed before 1.5.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # push version bump commit / tag and create the GitHub Release
+      id-token: write # mint the OIDC token for npm trusted publishing
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -27,6 +30,10 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      # OIDC trusted publishing requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Extract version from branch name
         id: extract_version
@@ -74,23 +81,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
-      - name: Verify npm authentication
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
-
       - name: Install dependencies
         run: npm install
 
       - name: Build package
         run: npm run build
 
+      # Auth is handled by npm OIDC trusted publishing (no NPM_TOKEN needed).
+      # Requires a Trusted Publisher configured on npmjs.com for this repo + release.yml.
       - name: Publish to NPM
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Why this targets `main` directly


PR #59 already merged the same change into `develop`. This PR cherry-picks that one commit onto `main` so both branches match.

## Safe to merge

- Only touches `.github/workflows/release.yml`
- The head branch is `ci/...`, which does **not** match the release job's `startsWith(head.ref, 'release/')` guard, so merging this will **not** trigger a publish
- Does not touch `package.json` (main stays at 1.5.2)

## Reminder

Configure the **Trusted Publisher** on npmjs.com (repo `Orcus2021/code-review-mcp-server`, workflow `release.yml`, allow `npm publish`) before releasing 1.5.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)